### PR TITLE
Only create a Tray icon on linux/windows

### DIFF
--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -23,7 +23,6 @@ function createWindow () {
    * Initial window options
    */
   const iconPath = path.join(__dirname, '../icons/icon.png')
-  tray = new Tray(iconPath)
   mainWindow = new BrowserWindow({
     width: 1000,
     height: 600,
@@ -58,7 +57,11 @@ function createWindow () {
     }
   ])
 
-  tray.setContextMenu(contextMenu)
+  if (process.platform === 'darwin') {
+    app.dock.setMenu(contextMenu)
+  } else {
+    tray = new Tray(iconPath)
+  }
 
   mainWindow.on('close', function (event) {
     event.preventDefault()


### PR DESCRIPTION
Currently, the code creates a tray on all platforms. On MacOS X
this creates an "application menu" in the upper right. However, this
is not needed at this time. Additionally, it requires a png to be
bundled which is currently not happening on MacOS X. This causes the
application not to launch at all.

This commit disables the creation of a tray in order to allow the app
to launch. In the future, we may add this functionality back.