### PR TITLE
Ensure we only persist state on important changes

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,29 @@ import modules from './modules'
 
 Vue.use(Vuex)
 
-const vuexLocal = new VuexPersistence({ storage: window.localStorage })
+const vuexLocal = new VuexPersistence({
+  storage: window.localStorage,
+  filter: (mutation) => {
+    console.log(mutation.type)
+    switch (mutation.type) {
+      case 'chats/sendMessageLocal':
+        return true
+      case 'chats/receiveMessage':
+        return true
+      case 'chats/deleteMessage':
+        return true
+      case 'chats/deleteChat':
+        return true
+      case 'chats/clearChat':
+        return true
+    }
+    if (mutation.type.startsWith('wallet/')) {
+      return true
+    }
+
+    return false
+  }
+})
 
 export default new Vuex.Store({
   modules,


### PR DESCRIPTION
Currently, we are persisting the entire state every time a key is
pressed. This is leading to a significant slowdown while typing
if there are any messages at all to be persisted. This commit adds
a filter to the vuex-persist plugin to only persist when certain
mutations are called.

This is a first pass at what mutations should trigger a persist. Future
work should look more closely at this and see if we cannot attach
the vuex-persist to only relevant stores.