### PR TITLE
Fix chatlist sorting to sort read chats by last read time

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -38,7 +38,7 @@
         :style="`background-size:cover; height: calc(100vh - ${height}px); border: 0; margin: 0; padding: 0; `"
     >
       <chat-list-item
-        v-for="(contact) in getValuedChatOrder"
+        v-for="(contact) in getSortedChatOrder"
         :key="contact.address"
         :chatAddr="contact.address"
         :numUnread="contact.unreadValue"
@@ -80,7 +80,7 @@ export default {
   computed: {
     ...mapGetters({
       getChatOrder: 'chats/getChatOrder',
-      getValuedChatOrder: 'chats/getValuedChatOrder',
+      getSortedChatOrder: 'chats/getSortedChatOrder',
       getNumUnread: 'chats/getNumUnread',
       getUnreadValue: 'chats/getUnreadValue',
       getBalanceVuex: 'wallet/getBalance',

--- a/src/store/modules/chats.js
+++ b/src/store/modules/chats.js
@@ -43,18 +43,16 @@ export default {
     getLastRead: (state) => (addr) => {
       return state.data[addr].lastRead
     },
-    getValuedChatOrder (state) {
+    getSortedChatOrder (state) {
       return state.order.map(
         addr => ({
           address: addr,
-          unreadValue: calculateUnreadValue(state, addr)
+          unreadValue: calculateUnreadValue(state, addr),
+          lastRead: state.data[addr].lastRead
         })
-      ).sort(({ address: addressA, unreadValue: valueA }, { address: addressB, unreadValue: valueB }) => {
-        if (state.activeChatAddr === addressA) {
-          return -Infinity
-        }
-        if (state.activeChatAddr === addressB) {
-          return Infinity
+      ).sort(({ unreadValue: valueA, lastRead: lastReadA }, { unreadValue: valueB, lastRead: lastReadB }) => {
+        if (valueA === valueB) {
+          return lastReadB - lastReadA
         }
         return valueB - valueA
       })


### PR DESCRIPTION
Previously, there was no tie-breaker for chats that were read. However,
it did pull the selected chat to the top of the list. This caused the
UI to be a little jumpy. To fix this, we sort any chats that have
the same values by the last time their chat was read.