### PR TITLE
Format unread value to have units and add back total unread messages

### DIFF
--- a/src/components/chat/ChatList.vue
+++ b/src/components/chat/ChatList.vue
@@ -41,7 +41,8 @@
         v-for="(contact) in getSortedChatOrder"
         :key="contact.address"
         :chatAddr="contact.address"
-        :numUnread="contact.unreadValue"
+        :valueUnread="formatBalance(contact.totalUnreadValue)"
+        :numUnread="contact.totalUnreadMessages"
       />
       <q-item v-if="getChatOrder.length === 0">
         <q-item-section>
@@ -75,6 +76,12 @@ export default {
   methods: {
     onResize (size) {
       this.height = size.height
+    },
+    formatBalance (balance) {
+      if (!balance) {
+        return balance
+      }
+      return formatting.formatBalance(balance)
     }
   },
   computed: {
@@ -82,7 +89,6 @@ export default {
       getChatOrder: 'chats/getChatOrder',
       getSortedChatOrder: 'chats/getSortedChatOrder',
       getNumUnread: 'chats/getNumUnread',
-      getUnreadValue: 'chats/getUnreadValue',
       getBalanceVuex: 'wallet/getBalance',
       walletConnected: 'electrumHandler/connected'
     }),

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -19,13 +19,20 @@
       >{{ latestMessageBody }}</q-item-label>
     </q-item-section>
     <q-item-section
-      v-if="numUnread !== 0"
       side
       top
     >
       <q-badge
-        color="info"
+        v-if="!!valueUnread"
+        color="primary"
+        :label="valueUnread"
+        class="q-my-xs"
+      />
+      <q-badge
+        v-if="!!numUnread"
+        color="secondary"
         :label="numUnread"
+        class="q-my-xs"
       />
     </q-item-section>
   </q-item>
@@ -62,6 +69,6 @@ export default {
       return this.getActiveChat() === this.chatAddr
     }
   },
-  props: ['chatAddr', 'numUnread']
+  props: ['chatAddr', 'numUnread', 'valueUnread']
 }
 </script>


### PR DESCRIPTION
Currently, we were only displaying the total number of unread sats.
This was somewhat unwiedly for large numbers, and it wasn't clear
to users what the number was intended to be. This commit adds the
appropriate currency formatting, and also adds back another chip which
shows the total number of unread messages.