### PR TITLE
Fix typo in `git submodule` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Clone this repository using
 ```bash
 git clone https://github.com/cashweb/ircash.git
 cd ircash
-git submodules update --init --recursive
+git submodule update --init --recursive
 ```
 
 ### Generating the Protobuf files


### PR DESCRIPTION
Remove excess `s` from the `git submodule` command instruction