### PR TITLE
Don't blit state to disk when running updateContact

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,6 +23,8 @@ const vuexLocal = new VuexPersistence({
         return false
       case 'chats/setInputMessageActive':
         return false
+      case 'contacts/updateContact':
+        return false
     }
 
     return true


### PR DESCRIPTION
This goes off every few seconds, and really slows down the system when
the entire state is written for every contact updated. This seems rather
excessive to cause a persistence run since we can do it after the wallet
restarts anyways.